### PR TITLE
Add webpack-svgstore-plugin

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -8,6 +8,7 @@ const webpack                 = require('webpack')
 const webpackDevMiddleware    = require('webpack-dev-middleware')
 const webpackHotMiddleware    = require('webpack-hot-middleware')
 const BowerWebpackPlugin      = require('bower-webpack-plugin')
+const SvgStoreWebpackPlugin   = require('webpack-svgstore-plugin')
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin')
 const Visualizer              = require('webpack-visualizer-plugin')
 const yaml                    = require('js-yaml')
@@ -297,6 +298,14 @@ const cfg = {
           $     : 'jquery',
           jQuery: 'jquery',
         }),
+        new SvgStoreWebpackPlugin({
+         svgoOptions: {
+           plugins: [
+             { removeTitle: true }
+           ]
+         },
+         prefix: 'icon-'
+       })
       ]
 
       if (runtime.isDev) {


### PR DESCRIPTION
It reads a folder of SVGs and produces one sprite that is later ajax-injected into the document body. Used like this in JS:

```js
var __svg__ = { path: '../icons/**/*.svg', name: 'assets/icons/[hash].icons.svg' }
require('webpack-svgstore-plugin/src/helpers/svgxhr')(__svg__)
```

And then in HTML:

```html
<svg class="icon"><use xlink:href="#icon-check"></use></svg>
```