### PR TITLE
Fixes for bundling some npm modules

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -619,9 +619,6 @@ const cfg = {
       // If false it will also try to use no extension from above
       enforceExtension: false,
 
-      // These extensions are tried when resolving a module
-      moduleExtensions: ['-loader'],
-
       // If false it's also try to use no module extension from above
       enforceModuleExtension: false,
       // These aliasing is used when trying to resolve a module

--- a/src/config.js
+++ b/src/config.js
@@ -604,7 +604,7 @@ const cfg = {
       descriptionFiles: ['package.json', 'bower.json'],
 
       // These fields in the description files are looked up when trying to resolve the package directory
-      mainFields: ['main', 'browser'],
+      mainFields: ['browser', 'main'],
 
       // These files are tried when trying to resolve a directory
       mainFiles: ['index'],


### PR DESCRIPTION
The first commit fixes bundling npm modules that have a browser entry point and a node entry point (like https://npm.im/debug).

The second commit fixes bundling modules that happen to have the same name as a Webpack loader that's also installed (like the https://npm.im/resolve-url module versus the https://npm.im/resolve-url-loader Webpack loader).