### PR TITLE
Babelrc: true to respect per-project babel config

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -487,7 +487,7 @@ const cfg = {
             {
               loader : 'babel-loader',
               options: {
-                babelrc: false,
+                babelrc: true,
                 presets: [
                   require.resolve('babel-preset-es2015'),
                   require.resolve('babel-preset-react'),


### PR DESCRIPTION
I tried locally, it seems to working fine, but not 100% sure. Could try and roll back if we catch :fire:?