### PR TITLE
Use pkill for cleaning up commands

### DIFF
--- a/src/dispatch.js
+++ b/src/dispatch.js
@@ -93,8 +93,8 @@ module.exports = async function dispatch () {
   utils.writeConfig(config)
 
   let cleanupCmds = [
-    `killall -m '.*nodemon.*'`,
-    `killall -m '.*browser-sync.*'`,
+    'pkill -f nodemon',
+    'pkill -f browser-sync',
   ]
 
   if (runtime.dockerSync && runtime.dockerSync.enabled === true) {


### PR DESCRIPTION
On Linux the killall command does not have the `-m` flag causing the cleanup commands to fail (compare https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/killall.1.html and https://linux.die.net/man/1/killall).

Using `pkill -f PATTERN` is an alternative that worked for me on Ubuntu and as far as my research went this should also work on MacOS but I wasn't able to test this. So please be cautious here.