### PR TITLE
Change sourcemaps in development

### DIFF
--- a/src/config.webpack.js
+++ b/src/config.webpack.js
@@ -104,7 +104,7 @@ module.exports = function ({runtime}) {
     devtool: (function dynamicDevtool () {
       // https://webpack.js.org/configuration/devtool/#devtool
       if (runtime.isDev) {
-        return 'inline-eval-cheap-source-map'
+        return 'eval-source-map'
       }
 
       return 'source-map'


### PR DESCRIPTION
Now we use `inline-eval-cheap-source-map` - takes 3647ms, but we’ll get transformed code without real line numbers:

![image](https://user-images.githubusercontent.com/7578559/65601307-45891180-dfbb-11e9-98ec-7649792d559d.png)

___

Here are 2 better options we can use instead (both of them return real line numbers and `es6`&`jsx` code).

1. ` source-map`, takes 8900ms/10169ms/7922ms

![image](https://user-images.githubusercontent.com/7578559/65601420-7e28eb00-dfbb-11e9-950d-adae7e772f8e.png)

2. `eval-source-map`, takes 3011ms/2643ms/2885ms

![image](https://user-images.githubusercontent.com/7578559/65601450-8aad4380-dfbb-11e9-9666-08d254a1c2c2.png)

___

I'm PRing with the `eval-source-map` option, because it takes much less time, even though logs are somewhat obscured (especially with this double-console-log issue I can't find the culprit of, @arturi?).