### PR TITLE
Support nested node_modules

### DIFF
--- a/src/config.webpack.js
+++ b/src/config.webpack.js
@@ -13,7 +13,7 @@ module.exports = function ({ runtime }) {
 
   const moduleDirs = [
     runtime.assetsSourceDir,
-    path.join(runtime.projectDir, 'node_modules'),
+    'node_modules',
     path.join(runtime.npmRoot, 'node_modules'),
     path.join(runtime.lanyonDir, 'node_modules'),
   ].concat(runtime.extraAssetsSourceDirs || [])


### PR DESCRIPTION
Support nested node_modules — specifying absolute paths makes Webpack… look only in root node_modules

This is the reason `tus-js-client@1.8.0` from `./node_modules/` was used instead of `tus-js-client@2.2.0` from  `./node_modules/@uppy/tus/tus-js-client`

Co-Authored-By: Renée Kooi <github@kooi.me>