### PR TITLE
Add `lanyon configure` command

### DIFF
--- a/src/dispatch.js
+++ b/src/dispatch.js
@@ -48,6 +48,7 @@ module.exports = async function dispatch () {
   }
 
   const scripts = {
+    configure            : (runtime, cb) => cb(null),
     'build:assets'       : `[webpack] ${extraWebpackFlags}--config [cacheDir]/webpack.config.js`,
     'build:content:watch': `${process.env.LANYON_DEBUG === '1' ? 'env DEBUG=nodemon:* ' : ''}[nodemon] --exitcrash --config [cacheDir]/nodemon.config.json --exec '${formattedBuildCmd} ${strPostBuildContentHooks}'`,
     'build:content'      : buildCmd,


### PR DESCRIPTION
This initializes the cache directory without running a build.

In the content repo, eslint requires that `.lanyon/webpack.config.js`
already exists, which it does not in a fresh clone on CI. Running
`lanyon configure` first would be a performant way to do that setup.