### PR TITLE
Fix `configure` in a fresh repo

### DIFF
--- a/src/dispatch.js
+++ b/src/dispatch.js
@@ -106,7 +106,7 @@ module.exports = async function dispatch () {
   }
 
   // Create asset dirs and git ignores
-  if (cmdName.match(/^build|start/)) {
+  if (cmdName.match(/^(build|configure|start)/)) {
     await utils.initProject(runtime)
   }
 


### PR DESCRIPTION
Oops, `lanyon configure` did try write the config files, but the .lanyon
directory is created by `initProject()` and not `writeConfig()`. So we
need to do both.

This time I actually removed my .lanyon directory before testing it, so it
should not unexpectedly fail on CI again 🤞🏻 🤞🏻 