### PR TITLE
Remove transpilation to CommonJS

### DIFF
--- a/src/config.webpack.js
+++ b/src/config.webpack.js
@@ -147,11 +147,7 @@ module.exports = function ({ runtime }) {
             cacheCompression: false,
             cacheDirectory  : `${runtime.cacheDir}/babel-loader`,
             presets         : [
-              [require.resolve('@babel/preset-env'), {
-                debug  : false,
-                modules: 'commonjs',
-                loose  : false,
-              }],
+              require.resolve('@babel/preset-env'),
               require.resolve('@babel/preset-react'),
             ],
             plugins: [


### PR DESCRIPTION
@babel/preset-env was configured to output CommonJS modules, but webpack
works better with ESM. This enables using dynamic imports for
code splitting, and allows webpack to concatenate modules for smaller bundles.

The other options had default values so I removed them.

I have one or two more PRs for lanyon in the pipeline with bugfixes so perhaps
it's best to wait with releasing this until those are also in.