### PR TITLE
Pass browser targets to babel-preset-env

### DIFF
--- a/src/config.webpack.js
+++ b/src/config.webpack.js
@@ -147,7 +147,9 @@ module.exports = function ({ runtime }) {
             cacheCompression: false,
             cacheDirectory  : `${runtime.cacheDir}/babel-loader`,
             presets         : [
-              require.resolve('@babel/preset-env'),
+              [require.resolve('@babel/preset-env'), {
+                targets: { browsers },
+              }],
               require.resolve('@babel/preset-react'),
             ],
             plugins: [


### PR DESCRIPTION
By default it targets ES5.